### PR TITLE
fix: index assets table on urn column

### DIFF
--- a/internal/store/postgres/migrations/000010_drop_assets_idx_urn_type_service.down.sql
+++ b/internal/store/postgres/migrations/000010_drop_assets_idx_urn_type_service.down.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS assets_idx_urn_type_service ON assets(urn,type,service);

--- a/internal/store/postgres/migrations/000010_drop_assets_idx_urn_type_service.up.sql
+++ b/internal/store/postgres/migrations/000010_drop_assets_idx_urn_type_service.up.sql
@@ -1,0 +1,4 @@
+-- By default, golang-migrate wraps multiple SQL statements in a transaction.
+-- Dropping index concurrently is not allowed in a transaction. So the drop
+-- statement needs to be the only statement in the migration.
+DROP INDEX CONCURRENTLY IF EXISTS assets_idx_urn_type_service;

--- a/internal/store/postgres/migrations/000011_create_idx_assets_urn.down.sql
+++ b/internal/store/postgres/migrations/000011_create_idx_assets_urn.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS assets_idx_urn;

--- a/internal/store/postgres/migrations/000011_create_idx_assets_urn.up.sql
+++ b/internal/store/postgres/migrations/000011_create_idx_assets_urn.up.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS assets_idx_urn ON assets(urn);


### PR DESCRIPTION
- Drop unique index on (urn, type, service) concurrently. This ensures
  that we don't take an exclusive lock on the table which would lock out
  selects, inserts, updates and deletes on the index's table.
- Create a unique index on urn column in the assets table.

Related to #162.