### PR TITLE
feat: manage assets with URN for GET/DELETE

### DIFF
--- a/core/asset/asset.go
+++ b/core/asset/asset.go
@@ -13,12 +13,13 @@ type Repository interface {
 	GetAll(context.Context, Filter) ([]Asset, error)
 	GetCount(context.Context, Filter) (int, error)
 	GetByID(ctx context.Context, id string) (Asset, error)
-	Find(ctx context.Context, urn string, typ Type, service string) (Asset, error)
+	GetByURN(ctx context.Context, urn string) (Asset, error)
 	GetVersionHistory(ctx context.Context, flt Filter, id string) ([]Asset, error)
 	GetByVersion(ctx context.Context, id string, version string) (Asset, error)
 	GetTypes(ctx context.Context, flt Filter) (map[Type]int, error)
 	Upsert(ctx context.Context, ast *Asset) (string, error)
-	Delete(ctx context.Context, id string) error
+	DeleteByID(ctx context.Context, id string) error
+	DeleteByURN(ctx context.Context, urn string) error
 }
 
 // Asset is a model that wraps arbitrary data with Compass' context

--- a/core/asset/discovery.go
+++ b/core/asset/discovery.go
@@ -7,7 +7,8 @@ import (
 
 type DiscoveryRepository interface {
 	Upsert(context.Context, Asset) error
-	Delete(ctx context.Context, assetID string) error
+	DeleteByID(ctx context.Context, assetID string) error
+	DeleteByURN(ctx context.Context, assetURN string) error
 	Search(ctx context.Context, cfg SearchConfig) (results []SearchResult, err error)
 	Suggest(ctx context.Context, cfg SearchConfig) (suggestions []string, err error)
 }

--- a/core/asset/errors.go
+++ b/core/asset/errors.go
@@ -7,6 +7,7 @@ import (
 
 var (
 	ErrEmptyID     = errors.New("asset does not have ID")
+	ErrEmptyURN    = errors.New("asset does not have URN")
 	ErrUnknownType = errors.New("unknown type")
 	ErrNilAsset    = errors.New("nil asset")
 )

--- a/core/asset/mocks/asset_repository.go
+++ b/core/asset/mocks/asset_repository.go
@@ -25,8 +25,8 @@ func (_m *AssetRepository) EXPECT() *AssetRepository_Expecter {
 	return &AssetRepository_Expecter{mock: &_m.Mock}
 }
 
-// Delete provides a mock function with given fields: ctx, id
-func (_m *AssetRepository) Delete(ctx context.Context, id string) error {
+// DeleteByID provides a mock function with given fields: ctx, id
+func (_m *AssetRepository) DeleteByID(ctx context.Context, id string) error {
 	ret := _m.Called(ctx, id)
 
 	var r0 error
@@ -39,74 +39,65 @@ func (_m *AssetRepository) Delete(ctx context.Context, id string) error {
 	return r0
 }
 
-// AssetRepository_Delete_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Delete'
-type AssetRepository_Delete_Call struct {
+// AssetRepository_DeleteByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteByID'
+type AssetRepository_DeleteByID_Call struct {
 	*mock.Call
 }
 
-// Delete is a helper method to define mock.On call
-//  - ctx context.Context
-//  - id string
-func (_e *AssetRepository_Expecter) Delete(ctx interface{}, id interface{}) *AssetRepository_Delete_Call {
-	return &AssetRepository_Delete_Call{Call: _e.mock.On("Delete", ctx, id)}
+// DeleteByID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *AssetRepository_Expecter) DeleteByID(ctx interface{}, id interface{}) *AssetRepository_DeleteByID_Call {
+	return &AssetRepository_DeleteByID_Call{Call: _e.mock.On("DeleteByID", ctx, id)}
 }
 
-func (_c *AssetRepository_Delete_Call) Run(run func(ctx context.Context, id string)) *AssetRepository_Delete_Call {
+func (_c *AssetRepository_DeleteByID_Call) Run(run func(ctx context.Context, id string)) *AssetRepository_DeleteByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
 
-func (_c *AssetRepository_Delete_Call) Return(_a0 error) *AssetRepository_Delete_Call {
+func (_c *AssetRepository_DeleteByID_Call) Return(_a0 error) *AssetRepository_DeleteByID_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-// Find provides a mock function with given fields: ctx, urn, typ, service
-func (_m *AssetRepository) Find(ctx context.Context, urn string, typ asset.Type, service string) (asset.Asset, error) {
-	ret := _m.Called(ctx, urn, typ, service)
+// DeleteByURN provides a mock function with given fields: ctx, urn
+func (_m *AssetRepository) DeleteByURN(ctx context.Context, urn string) error {
+	ret := _m.Called(ctx, urn)
 
-	var r0 asset.Asset
-	if rf, ok := ret.Get(0).(func(context.Context, string, asset.Type, string) asset.Asset); ok {
-		r0 = rf(ctx, urn, typ, service)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, urn)
 	} else {
-		r0 = ret.Get(0).(asset.Asset)
+		r0 = ret.Error(0)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, asset.Type, string) error); ok {
-		r1 = rf(ctx, urn, typ, service)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
-// AssetRepository_Find_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Find'
-type AssetRepository_Find_Call struct {
+// AssetRepository_DeleteByURN_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteByURN'
+type AssetRepository_DeleteByURN_Call struct {
 	*mock.Call
 }
 
-// Find is a helper method to define mock.On call
-//  - ctx context.Context
-//  - urn string
-//  - typ asset.Type
-//  - service string
-func (_e *AssetRepository_Expecter) Find(ctx interface{}, urn interface{}, typ interface{}, service interface{}) *AssetRepository_Find_Call {
-	return &AssetRepository_Find_Call{Call: _e.mock.On("Find", ctx, urn, typ, service)}
+// DeleteByURN is a helper method to define mock.On call
+//   - ctx context.Context
+//   - urn string
+func (_e *AssetRepository_Expecter) DeleteByURN(ctx interface{}, urn interface{}) *AssetRepository_DeleteByURN_Call {
+	return &AssetRepository_DeleteByURN_Call{Call: _e.mock.On("DeleteByURN", ctx, urn)}
 }
 
-func (_c *AssetRepository_Find_Call) Run(run func(ctx context.Context, urn string, typ asset.Type, service string)) *AssetRepository_Find_Call {
+func (_c *AssetRepository_DeleteByURN_Call) Run(run func(ctx context.Context, urn string)) *AssetRepository_DeleteByURN_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(asset.Type), args[3].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
 
-func (_c *AssetRepository_Find_Call) Return(_a0 asset.Asset, _a1 error) *AssetRepository_Find_Call {
-	_c.Call.Return(_a0, _a1)
+func (_c *AssetRepository_DeleteByURN_Call) Return(_a0 error) *AssetRepository_DeleteByURN_Call {
+	_c.Call.Return(_a0)
 	return _c
 }
 
@@ -139,8 +130,8 @@ type AssetRepository_GetAll_Call struct {
 }
 
 // GetAll is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 asset.Filter
+//   - _a0 context.Context
+//   - _a1 asset.Filter
 func (_e *AssetRepository_Expecter) GetAll(_a0 interface{}, _a1 interface{}) *AssetRepository_GetAll_Call {
 	return &AssetRepository_GetAll_Call{Call: _e.mock.On("GetAll", _a0, _a1)}
 }
@@ -184,8 +175,8 @@ type AssetRepository_GetByID_Call struct {
 }
 
 // GetByID is a helper method to define mock.On call
-//  - ctx context.Context
-//  - id string
+//   - ctx context.Context
+//   - id string
 func (_e *AssetRepository_Expecter) GetByID(ctx interface{}, id interface{}) *AssetRepository_GetByID_Call {
 	return &AssetRepository_GetByID_Call{Call: _e.mock.On("GetByID", ctx, id)}
 }
@@ -198,6 +189,51 @@ func (_c *AssetRepository_GetByID_Call) Run(run func(ctx context.Context, id str
 }
 
 func (_c *AssetRepository_GetByID_Call) Return(_a0 asset.Asset, _a1 error) *AssetRepository_GetByID_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+// GetByURN provides a mock function with given fields: ctx, urn
+func (_m *AssetRepository) GetByURN(ctx context.Context, urn string) (asset.Asset, error) {
+	ret := _m.Called(ctx, urn)
+
+	var r0 asset.Asset
+	if rf, ok := ret.Get(0).(func(context.Context, string) asset.Asset); ok {
+		r0 = rf(ctx, urn)
+	} else {
+		r0 = ret.Get(0).(asset.Asset)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, urn)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// AssetRepository_GetByURN_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetByURN'
+type AssetRepository_GetByURN_Call struct {
+	*mock.Call
+}
+
+// GetByURN is a helper method to define mock.On call
+//   - ctx context.Context
+//   - urn string
+func (_e *AssetRepository_Expecter) GetByURN(ctx interface{}, urn interface{}) *AssetRepository_GetByURN_Call {
+	return &AssetRepository_GetByURN_Call{Call: _e.mock.On("GetByURN", ctx, urn)}
+}
+
+func (_c *AssetRepository_GetByURN_Call) Run(run func(ctx context.Context, urn string)) *AssetRepository_GetByURN_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *AssetRepository_GetByURN_Call) Return(_a0 asset.Asset, _a1 error) *AssetRepository_GetByURN_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
@@ -229,9 +265,9 @@ type AssetRepository_GetByVersion_Call struct {
 }
 
 // GetByVersion is a helper method to define mock.On call
-//  - ctx context.Context
-//  - id string
-//  - version string
+//   - ctx context.Context
+//   - id string
+//   - version string
 func (_e *AssetRepository_Expecter) GetByVersion(ctx interface{}, id interface{}, version interface{}) *AssetRepository_GetByVersion_Call {
 	return &AssetRepository_GetByVersion_Call{Call: _e.mock.On("GetByVersion", ctx, id, version)}
 }
@@ -275,8 +311,8 @@ type AssetRepository_GetCount_Call struct {
 }
 
 // GetCount is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 asset.Filter
+//   - _a0 context.Context
+//   - _a1 asset.Filter
 func (_e *AssetRepository_Expecter) GetCount(_a0 interface{}, _a1 interface{}) *AssetRepository_GetCount_Call {
 	return &AssetRepository_GetCount_Call{Call: _e.mock.On("GetCount", _a0, _a1)}
 }
@@ -322,8 +358,8 @@ type AssetRepository_GetTypes_Call struct {
 }
 
 // GetTypes is a helper method to define mock.On call
-//  - ctx context.Context
-//  - flt asset.Filter
+//   - ctx context.Context
+//   - flt asset.Filter
 func (_e *AssetRepository_Expecter) GetTypes(ctx interface{}, flt interface{}) *AssetRepository_GetTypes_Call {
 	return &AssetRepository_GetTypes_Call{Call: _e.mock.On("GetTypes", ctx, flt)}
 }
@@ -369,9 +405,9 @@ type AssetRepository_GetVersionHistory_Call struct {
 }
 
 // GetVersionHistory is a helper method to define mock.On call
-//  - ctx context.Context
-//  - flt asset.Filter
-//  - id string
+//   - ctx context.Context
+//   - flt asset.Filter
+//   - id string
 func (_e *AssetRepository_Expecter) GetVersionHistory(ctx interface{}, flt interface{}, id interface{}) *AssetRepository_GetVersionHistory_Call {
 	return &AssetRepository_GetVersionHistory_Call{Call: _e.mock.On("GetVersionHistory", ctx, flt, id)}
 }
@@ -415,8 +451,8 @@ type AssetRepository_Upsert_Call struct {
 }
 
 // Upsert is a helper method to define mock.On call
-//  - ctx context.Context
-//  - ast *asset.Asset
+//   - ctx context.Context
+//   - ast *asset.Asset
 func (_e *AssetRepository_Expecter) Upsert(ctx interface{}, ast interface{}) *AssetRepository_Upsert_Call {
 	return &AssetRepository_Upsert_Call{Call: _e.mock.On("Upsert", ctx, ast)}
 }

--- a/core/asset/mocks/discovery_repository.go
+++ b/core/asset/mocks/discovery_repository.go
@@ -25,8 +25,8 @@ func (_m *DiscoveryRepository) EXPECT() *DiscoveryRepository_Expecter {
 	return &DiscoveryRepository_Expecter{mock: &_m.Mock}
 }
 
-// Delete provides a mock function with given fields: ctx, assetID
-func (_m *DiscoveryRepository) Delete(ctx context.Context, assetID string) error {
+// DeleteByID provides a mock function with given fields: ctx, assetID
+func (_m *DiscoveryRepository) DeleteByID(ctx context.Context, assetID string) error {
 	ret := _m.Called(ctx, assetID)
 
 	var r0 error
@@ -39,26 +39,64 @@ func (_m *DiscoveryRepository) Delete(ctx context.Context, assetID string) error
 	return r0
 }
 
-// DiscoveryRepository_Delete_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Delete'
-type DiscoveryRepository_Delete_Call struct {
+// DiscoveryRepository_DeleteByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteByID'
+type DiscoveryRepository_DeleteByID_Call struct {
 	*mock.Call
 }
 
-// Delete is a helper method to define mock.On call
-//  - ctx context.Context
-//  - assetID string
-func (_e *DiscoveryRepository_Expecter) Delete(ctx interface{}, assetID interface{}) *DiscoveryRepository_Delete_Call {
-	return &DiscoveryRepository_Delete_Call{Call: _e.mock.On("Delete", ctx, assetID)}
+// DeleteByID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - assetID string
+func (_e *DiscoveryRepository_Expecter) DeleteByID(ctx interface{}, assetID interface{}) *DiscoveryRepository_DeleteByID_Call {
+	return &DiscoveryRepository_DeleteByID_Call{Call: _e.mock.On("DeleteByID", ctx, assetID)}
 }
 
-func (_c *DiscoveryRepository_Delete_Call) Run(run func(ctx context.Context, assetID string)) *DiscoveryRepository_Delete_Call {
+func (_c *DiscoveryRepository_DeleteByID_Call) Run(run func(ctx context.Context, assetID string)) *DiscoveryRepository_DeleteByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
 
-func (_c *DiscoveryRepository_Delete_Call) Return(_a0 error) *DiscoveryRepository_Delete_Call {
+func (_c *DiscoveryRepository_DeleteByID_Call) Return(_a0 error) *DiscoveryRepository_DeleteByID_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+// DeleteByURN provides a mock function with given fields: ctx, assetURN
+func (_m *DiscoveryRepository) DeleteByURN(ctx context.Context, assetURN string) error {
+	ret := _m.Called(ctx, assetURN)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, assetURN)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DiscoveryRepository_DeleteByURN_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteByURN'
+type DiscoveryRepository_DeleteByURN_Call struct {
+	*mock.Call
+}
+
+// DeleteByURN is a helper method to define mock.On call
+//   - ctx context.Context
+//   - assetURN string
+func (_e *DiscoveryRepository_Expecter) DeleteByURN(ctx interface{}, assetURN interface{}) *DiscoveryRepository_DeleteByURN_Call {
+	return &DiscoveryRepository_DeleteByURN_Call{Call: _e.mock.On("DeleteByURN", ctx, assetURN)}
+}
+
+func (_c *DiscoveryRepository_DeleteByURN_Call) Run(run func(ctx context.Context, assetURN string)) *DiscoveryRepository_DeleteByURN_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *DiscoveryRepository_DeleteByURN_Call) Return(_a0 error) *DiscoveryRepository_DeleteByURN_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
@@ -92,8 +130,8 @@ type DiscoveryRepository_Search_Call struct {
 }
 
 // Search is a helper method to define mock.On call
-//  - ctx context.Context
-//  - cfg asset.SearchConfig
+//   - ctx context.Context
+//   - cfg asset.SearchConfig
 func (_e *DiscoveryRepository_Expecter) Search(ctx interface{}, cfg interface{}) *DiscoveryRepository_Search_Call {
 	return &DiscoveryRepository_Search_Call{Call: _e.mock.On("Search", ctx, cfg)}
 }
@@ -139,8 +177,8 @@ type DiscoveryRepository_Suggest_Call struct {
 }
 
 // Suggest is a helper method to define mock.On call
-//  - ctx context.Context
-//  - cfg asset.SearchConfig
+//   - ctx context.Context
+//   - cfg asset.SearchConfig
 func (_e *DiscoveryRepository_Expecter) Suggest(ctx interface{}, cfg interface{}) *DiscoveryRepository_Suggest_Call {
 	return &DiscoveryRepository_Suggest_Call{Call: _e.mock.On("Suggest", ctx, cfg)}
 }
@@ -177,8 +215,8 @@ type DiscoveryRepository_Upsert_Call struct {
 }
 
 // Upsert is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 asset.Asset
+//   - _a0 context.Context
+//   - _a1 asset.Asset
 func (_e *DiscoveryRepository_Expecter) Upsert(_a0 interface{}, _a1 interface{}) *DiscoveryRepository_Upsert_Call {
 	return &DiscoveryRepository_Upsert_Call{Call: _e.mock.On("Upsert", _a0, _a1)}
 }

--- a/internal/server/v1beta1/asset_test.go
+++ b/internal/server/v1beta1/asset_test.go
@@ -399,7 +399,7 @@ func TestUpsertPatchAsset(t *testing.T) {
 			Description: "should return internal server error when finding asset failed",
 			Setup: func(ctx context.Context, as *mocks.AssetService) {
 				expectedErr := errors.New("unknown error")
-				as.EXPECT().GetAssetByURN(ctx, "test dagger", asset.TypeTable, "kafka").Return(currentAsset, expectedErr)
+				as.EXPECT().GetAssetByID(ctx, "test dagger").Return(currentAsset, expectedErr)
 			},
 			Request:      validPayload,
 			ExpectStatus: codes.Internal,
@@ -408,7 +408,7 @@ func TestUpsertPatchAsset(t *testing.T) {
 			Description: "should return internal server error when upserting asset service failed",
 			Setup: func(ctx context.Context, as *mocks.AssetService) {
 				expectedErr := errors.New("unknown error")
-				as.EXPECT().GetAssetByURN(ctx, "test dagger", asset.TypeTable, "kafka").Return(currentAsset, nil)
+				as.EXPECT().GetAssetByID(ctx, "test dagger").Return(currentAsset, nil)
 				as.EXPECT().UpsertPatchAsset(ctx, mock.AnythingOfType("*asset.Asset"), mock.AnythingOfType("[]asset.LineageNode"), mock.AnythingOfType("[]asset.LineageNode")).Return("1234-5678", expectedErr)
 			},
 			Request:      validPayload,
@@ -437,7 +437,7 @@ func TestUpsertPatchAsset(t *testing.T) {
 				assetWithID := patchedAsset
 				assetWithID.ID = assetID
 
-				as.EXPECT().GetAssetByURN(ctx, "test dagger", asset.TypeTable, "kafka").Return(currentAsset, nil)
+				as.EXPECT().GetAssetByID(ctx, "test dagger").Return(currentAsset, nil)
 				as.EXPECT().UpsertPatchAsset(ctx, &patchedAsset, upstreams, downstreams).Return(assetWithID.ID, nil).Run(func(ctx context.Context, ast *asset.Asset, upstreams, downstreams []asset.LineageNode) {
 					patchedAsset.ID = assetWithID.ID
 				})

--- a/internal/server/v1beta1/mocks/asset_service.go
+++ b/internal/server/v1beta1/mocks/asset_service.go
@@ -45,8 +45,8 @@ type AssetService_DeleteAsset_Call struct {
 }
 
 // DeleteAsset is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 string
+//   - _a0 context.Context
+//   - _a1 string
 func (_e *AssetService_Expecter) DeleteAsset(_a0 interface{}, _a1 interface{}) *AssetService_DeleteAsset_Call {
 	return &AssetService_DeleteAsset_Call{Call: _e.mock.On("DeleteAsset", _a0, _a1)}
 }
@@ -99,9 +99,9 @@ type AssetService_GetAllAssets_Call struct {
 }
 
 // GetAllAssets is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 asset.Filter
-//  - _a2 bool
+//   - _a0 context.Context
+//   - _a1 asset.Filter
+//   - _a2 bool
 func (_e *AssetService_Expecter) GetAllAssets(_a0 interface{}, _a1 interface{}, _a2 interface{}) *AssetService_GetAllAssets_Call {
 	return &AssetService_GetAllAssets_Call{Call: _e.mock.On("GetAllAssets", _a0, _a1, _a2)}
 }
@@ -145,8 +145,8 @@ type AssetService_GetAssetByID_Call struct {
 }
 
 // GetAssetByID is a helper method to define mock.On call
-//  - ctx context.Context
-//  - id string
+//   - ctx context.Context
+//   - id string
 func (_e *AssetService_Expecter) GetAssetByID(ctx interface{}, id interface{}) *AssetService_GetAssetByID_Call {
 	return &AssetService_GetAssetByID_Call{Call: _e.mock.On("GetAssetByID", ctx, id)}
 }
@@ -159,53 +159,6 @@ func (_c *AssetService_GetAssetByID_Call) Run(run func(ctx context.Context, id s
 }
 
 func (_c *AssetService_GetAssetByID_Call) Return(_a0 asset.Asset, _a1 error) *AssetService_GetAssetByID_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-// GetAssetByURN provides a mock function with given fields: ctx, urn, typ, service
-func (_m *AssetService) GetAssetByURN(ctx context.Context, urn string, typ asset.Type, service string) (asset.Asset, error) {
-	ret := _m.Called(ctx, urn, typ, service)
-
-	var r0 asset.Asset
-	if rf, ok := ret.Get(0).(func(context.Context, string, asset.Type, string) asset.Asset); ok {
-		r0 = rf(ctx, urn, typ, service)
-	} else {
-		r0 = ret.Get(0).(asset.Asset)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, asset.Type, string) error); ok {
-		r1 = rf(ctx, urn, typ, service)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// AssetService_GetAssetByURN_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAssetByURN'
-type AssetService_GetAssetByURN_Call struct {
-	*mock.Call
-}
-
-// GetAssetByURN is a helper method to define mock.On call
-//  - ctx context.Context
-//  - urn string
-//  - typ asset.Type
-//  - service string
-func (_e *AssetService_Expecter) GetAssetByURN(ctx interface{}, urn interface{}, typ interface{}, service interface{}) *AssetService_GetAssetByURN_Call {
-	return &AssetService_GetAssetByURN_Call{Call: _e.mock.On("GetAssetByURN", ctx, urn, typ, service)}
-}
-
-func (_c *AssetService_GetAssetByURN_Call) Run(run func(ctx context.Context, urn string, typ asset.Type, service string)) *AssetService_GetAssetByURN_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(asset.Type), args[3].(string))
-	})
-	return _c
-}
-
-func (_c *AssetService_GetAssetByURN_Call) Return(_a0 asset.Asset, _a1 error) *AssetService_GetAssetByURN_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
@@ -237,9 +190,9 @@ type AssetService_GetAssetByVersion_Call struct {
 }
 
 // GetAssetByVersion is a helper method to define mock.On call
-//  - ctx context.Context
-//  - id string
-//  - version string
+//   - ctx context.Context
+//   - id string
+//   - version string
 func (_e *AssetService_Expecter) GetAssetByVersion(ctx interface{}, id interface{}, version interface{}) *AssetService_GetAssetByVersion_Call {
 	return &AssetService_GetAssetByVersion_Call{Call: _e.mock.On("GetAssetByVersion", ctx, id, version)}
 }
@@ -285,9 +238,9 @@ type AssetService_GetAssetVersionHistory_Call struct {
 }
 
 // GetAssetVersionHistory is a helper method to define mock.On call
-//  - ctx context.Context
-//  - flt asset.Filter
-//  - id string
+//   - ctx context.Context
+//   - flt asset.Filter
+//   - id string
 func (_e *AssetService_Expecter) GetAssetVersionHistory(ctx interface{}, flt interface{}, id interface{}) *AssetService_GetAssetVersionHistory_Call {
 	return &AssetService_GetAssetVersionHistory_Call{Call: _e.mock.On("GetAssetVersionHistory", ctx, flt, id)}
 }
@@ -333,9 +286,9 @@ type AssetService_GetLineage_Call struct {
 }
 
 // GetLineage is a helper method to define mock.On call
-//  - ctx context.Context
-//  - node asset.LineageNode
-//  - query asset.LineageQuery
+//   - ctx context.Context
+//   - node asset.LineageNode
+//   - query asset.LineageQuery
 func (_e *AssetService_Expecter) GetLineage(ctx interface{}, node interface{}, query interface{}) *AssetService_GetLineage_Call {
 	return &AssetService_GetLineage_Call{Call: _e.mock.On("GetLineage", ctx, node, query)}
 }
@@ -381,8 +334,8 @@ type AssetService_GetTypes_Call struct {
 }
 
 // GetTypes is a helper method to define mock.On call
-//  - ctx context.Context
-//  - flt asset.Filter
+//   - ctx context.Context
+//   - flt asset.Filter
 func (_e *AssetService_Expecter) GetTypes(ctx interface{}, flt interface{}) *AssetService_GetTypes_Call {
 	return &AssetService_GetTypes_Call{Call: _e.mock.On("GetTypes", ctx, flt)}
 }
@@ -428,8 +381,8 @@ type AssetService_SearchAssets_Call struct {
 }
 
 // SearchAssets is a helper method to define mock.On call
-//  - ctx context.Context
-//  - cfg asset.SearchConfig
+//   - ctx context.Context
+//   - cfg asset.SearchConfig
 func (_e *AssetService_Expecter) SearchAssets(ctx interface{}, cfg interface{}) *AssetService_SearchAssets_Call {
 	return &AssetService_SearchAssets_Call{Call: _e.mock.On("SearchAssets", ctx, cfg)}
 }
@@ -475,8 +428,8 @@ type AssetService_SuggestAssets_Call struct {
 }
 
 // SuggestAssets is a helper method to define mock.On call
-//  - ctx context.Context
-//  - cfg asset.SearchConfig
+//   - ctx context.Context
+//   - cfg asset.SearchConfig
 func (_e *AssetService_Expecter) SuggestAssets(ctx interface{}, cfg interface{}) *AssetService_SuggestAssets_Call {
 	return &AssetService_SuggestAssets_Call{Call: _e.mock.On("SuggestAssets", ctx, cfg)}
 }
@@ -520,10 +473,10 @@ type AssetService_UpsertPatchAsset_Call struct {
 }
 
 // UpsertPatchAsset is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 *asset.Asset
-//  - _a2 []asset.LineageNode
-//  - _a3 []asset.LineageNode
+//   - _a0 context.Context
+//   - _a1 *asset.Asset
+//   - _a2 []asset.LineageNode
+//   - _a3 []asset.LineageNode
 func (_e *AssetService_Expecter) UpsertPatchAsset(_a0 interface{}, _a1 interface{}, _a2 interface{}, _a3 interface{}) *AssetService_UpsertPatchAsset_Call {
 	return &AssetService_UpsertPatchAsset_Call{Call: _e.mock.On("UpsertPatchAsset", _a0, _a1, _a2, _a3)}
 }


### PR DESCRIPTION
- On the service layer, for get and delete, check if the given ID is a
  UUID and call corresponding method on repository (ex: GetByID or
  GetByURN). This introduces a limitation into the system where if an
  asset's URN is a UUID, the get and delete calls will fail. This
  limitation is considered acceptable in the short term and in the long
  term, the plan is to drop support for get or delete by ID. ID will be
  internal to Compass.
- On the repository layer for PG and ES, add get and delete by URN
  variants.
- Drop the Find method on asset repository and replace usages with
  GetWithURN.

BREAKING CHANGE: The interface for asset Repository and
DiscoveryRepository have been changed - methods have been renamed and
new methods have been added.

Closes #162 