### PR TITLE
fix: require timestamp for adding asset probe

### DIFF
--- a/internal/server/v1beta1/asset.go
+++ b/internal/server/v1beta1/asset.go
@@ -318,6 +318,9 @@ func (server *APIServer) CreateAssetProbe(ctx context.Context, req *compassv1bet
 	if req.Probe.Status == "" {
 		return nil, status.Error(codes.InvalidArgument, "Status is required")
 	}
+	if !req.Probe.Timestamp.IsValid() {
+		return nil, status.Error(codes.InvalidArgument, "Timestamp is required")
+	}
 
 	probe := asset.Probe{
 		Status:       req.Probe.Status,

--- a/internal/server/v1beta1/asset_test.go
+++ b/internal/server/v1beta1/asset_test.go
@@ -1120,11 +1120,23 @@ func TestCreateAssetProbe(t *testing.T) {
 
 	var testCases = []testCase{
 		{
-			Description:  `should return error if payload is invalid`,
+			Description:  `should return error if status is missing`,
 			ExpectStatus: codes.InvalidArgument,
 			Request: &compassv1beta1.CreateAssetProbeRequest{
 				AssetUrn: assetURN,
-				Probe:    &compassv1beta1.CreateAssetProbeRequest_Probe{},
+				Probe: &compassv1beta1.CreateAssetProbeRequest_Probe{
+					Timestamp: timestamppb.New(now),
+				},
+			},
+		},
+		{
+			Description:  `should return error if timestamp is missing`,
+			ExpectStatus: codes.InvalidArgument,
+			Request: &compassv1beta1.CreateAssetProbeRequest{
+				AssetUrn: assetURN,
+				Probe: &compassv1beta1.CreateAssetProbeRequest_Probe{
+					Status: "RUNNING",
+				},
 			},
 		},
 		{
@@ -1133,7 +1145,8 @@ func TestCreateAssetProbe(t *testing.T) {
 			Request: &compassv1beta1.CreateAssetProbeRequest{
 				AssetUrn: assetURN,
 				Probe: &compassv1beta1.CreateAssetProbeRequest_Probe{
-					Status: "RUNNING",
+					Status:    "RUNNING",
+					Timestamp: timestamppb.New(now),
 				},
 			},
 			Setup: func(ctx context.Context, as *mocks.AssetService) {
@@ -1148,7 +1161,8 @@ func TestCreateAssetProbe(t *testing.T) {
 			Request: &compassv1beta1.CreateAssetProbeRequest{
 				AssetUrn: assetURN,
 				Probe: &compassv1beta1.CreateAssetProbeRequest_Probe{
-					Status: "RUNNING",
+					Status:    "RUNNING",
+					Timestamp: timestamppb.New(now),
 				},
 			},
 			Setup: func(ctx context.Context, as *mocks.AssetService) {


### PR DESCRIPTION
Fixes #182 