### PR TITLE
chore: increase grpc max call send & receive msg size

### DIFF
--- a/compass.yaml.example
+++ b/compass.yaml.example
@@ -24,11 +24,14 @@ db:
 service:
     host: localhost
     port: 8080
-    grpc_port: 8081
     identity:
         headerkey_uuid: Compass-User-UUID
         headerkey_email: Compass-User-Email
         provider_default_name: shield
+    grpc:
+        port: 8081
+        max_send_msg_size: 33554432
+        max_recv_msg_size: 33554432
 
 client:
     host: localhost:8080

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,6 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
-	golang.org/x/net v0.0.0-20220919232410-f2f64ebce3c1
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 // indirect
 	google.golang.org/genproto v0.0.0-20220822174746-9e6da59bd2fc
 	google.golang.org/grpc v1.49.0

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,22 +30,20 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
-const (
-	GRPCMaxClientSendSize = 32 << 20
-)
-
 type Config struct {
-	Host     string `mapstructure:"host" default:"0.0.0.0"`
-	Port     int    `mapstructure:"port" default:"8080"`
-	GRPCPort int    `mapstructure:"grpc_port" default:"8081"`
-	BaseUrl  string `mapstructure:"baseurl" default:"localhost:8080"`
+	Host    string `mapstructure:"host" default:"0.0.0.0"`
+	Port    int    `mapstructure:"port" default:"8080"`
+	BaseUrl string `mapstructure:"baseurl" default:"localhost:8080"`
 
 	// User Identity
 	Identity IdentityConfig `mapstructure:"identity"`
+
+	// GRPC Config
+	GRPC GRPCConfig `mapstructure:"grpc"`
 }
 
 func (cfg Config) addr() string     { return fmt.Sprintf("%s:%d", cfg.Host, cfg.Port) }
-func (cfg Config) grpcAddr() string { return fmt.Sprintf("%s:%d", cfg.Host, cfg.GRPCPort) }
+func (cfg Config) grpcAddr() string { return fmt.Sprintf("%s:%d", cfg.Host, cfg.GRPC.Port) }
 
 type IdentityConfig struct {
 	// User Identity
@@ -53,6 +51,12 @@ type IdentityConfig struct {
 	HeaderValueUUID     string `mapstructure:"headervalue_uuid" default:"odpf@email.com"`
 	HeaderKeyEmail      string `mapstructure:"headerkey_email" default:"Compass-User-Email"`
 	ProviderDefaultName string `mapstructure:"provider_default_name" default:""`
+}
+
+type GRPCConfig struct {
+	Port           int `mapstructure:"port" default:"8081"`
+	MaxRecvMsgSize int `mapstructure:"max_recv_msg_size" default:"33554432"`
+	MaxSendMsgSize int `mapstructure:"max_send_msg_size" default:"33554432"`
 }
 
 func Serve(
@@ -109,8 +113,8 @@ func Serve(
 		config.grpcAddr(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(GRPCMaxClientSendSize),
-			grpc.MaxCallSendMsgSize(GRPCMaxClientSendSize),
+			grpc.MaxCallRecvMsgSize(config.GRPC.MaxRecvMsgSize),
+			grpc.MaxCallSendMsgSize(config.GRPC.MaxSendMsgSize),
 		))
 	if err != nil {
 		return err

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,6 +30,10 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
+const (
+	GRPCMaxClientSendSize = 32 << 20
+)
+
 type Config struct {
 	Host     string `mapstructure:"host" default:"0.0.0.0"`
 	Port     int    `mapstructure:"port" default:"8080"`
@@ -100,7 +104,14 @@ func Serve(
 
 	headerMatcher := makeHeaderMatcher(config)
 
-	grpcConn, err := grpc.DialContext(grpcDialCtx, config.grpcAddr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	grpcConn, err := grpc.DialContext(
+		grpcDialCtx,
+		config.grpcAddr(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(GRPCMaxClientSendSize),
+			grpc.MaxCallSendMsgSize(GRPCMaxClientSendSize),
+		))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* Increase the grpc max call send & receive msg size to `32MB` from default `4MB`.