### PR TITLE
fix: include asset's owners info in response

### DIFF
--- a/internal/server/v1beta1/asset_test.go
+++ b/internal/server/v1beta1/asset_test.go
@@ -101,19 +101,19 @@ func TestGetAllAssets(t *testing.T) {
 			Setup: func(ctx context.Context, as *mocks.AssetService) {
 				as.EXPECT().GetAllAssets(ctx, asset.Filter{}, false).Return([]asset.Asset{
 					{ID: "testid-1"},
-					{ID: "testid-2"},
+					{ID: "testid-2", Owners: []user.User{{Email: "dummy@trash.com"}}},
 				}, 0, nil)
 			},
 			PostCheck: func(resp *compassv1beta1.GetAllAssetsResponse) error {
 				expected := &compassv1beta1.GetAllAssetsResponse{
 					Data: []*compassv1beta1.Asset{
 						{Id: "testid-1"},
-						{Id: "testid-2"},
+						{Id: "testid-2", Owners: []*compassv1beta1.User{{Email: "dummy@trash.com"}}},
 					},
 				}
 
-				if diff := cmp.Diff(resp, expected, protocmp.Transform()); diff != "" {
-					return fmt.Errorf("expected response to be %+v, was %+v", expected, resp)
+				if d := cmp.Diff(resp, expected, protocmp.Transform()); d != "" {
+					return fmt.Errorf("expected response to be %+v, was %+v\n\tdiff: %s", expected, resp, d)
 				}
 				return nil
 			},
@@ -197,7 +197,8 @@ func TestGetAssetByID(t *testing.T) {
 		assetID  = uuid.NewString()
 		now      = time.Now()
 		ast      = asset.Asset{
-			ID: assetID,
+			ID:     assetID,
+			Owners: []user.User{{Email: "dummy@trash.com"}},
 			Probes: []asset.Probe{
 				{
 					ID:           uuid.NewString(),
@@ -260,7 +261,8 @@ func TestGetAssetByID(t *testing.T) {
 			PostCheck: func(resp *compassv1beta1.GetAssetByIDResponse) error {
 				expected := &compassv1beta1.GetAssetByIDResponse{
 					Data: &compassv1beta1.Asset{
-						Id: assetID,
+						Id:     assetID,
+						Owners: []*compassv1beta1.User{{Email: "dummy@trash.com"}},
 						Probes: []*compassv1beta1.Probe{
 							{
 								Id:           ast.Probes[0].ID,
@@ -282,8 +284,8 @@ func TestGetAssetByID(t *testing.T) {
 						},
 					},
 				}
-				if diff := cmp.Diff(resp, expected, protocmp.Transform()); diff != "" {
-					return fmt.Errorf("mismatch (-want +got):\n%s", diff)
+				if d := cmp.Diff(resp, expected, protocmp.Transform()); d != "" {
+					return fmt.Errorf("mismatch (-want +got):\n%s", d)
 				}
 				return nil
 			},
@@ -1097,6 +1099,7 @@ func TestGetAssetByVersion(t *testing.T) {
 		ast      = asset.Asset{
 			ID:      assetID,
 			Version: version,
+			Owners:  []user.User{{Email: "dummy@trash.com"}},
 		}
 	)
 
@@ -1156,10 +1159,11 @@ func TestGetAssetByVersion(t *testing.T) {
 				expected := &compassv1beta1.GetAssetByVersionResponse{
 					Data: &compassv1beta1.Asset{
 						Id:      assetID,
+						Owners:  []*compassv1beta1.User{{Email: "dummy@trash.com"}},
 						Version: version,
 					},
 				}
-				if diff := cmp.Diff(resp, expected, protocmp.Transform()); diff != "" {
+				if d := cmp.Diff(resp, expected, protocmp.Transform()); d != "" {
 					return fmt.Errorf("expected response to be %+v, was %+v", expected, resp)
 				}
 				return nil
@@ -1369,6 +1373,7 @@ func TestAssetToProto(t *testing.T) {
 				Data: map[string]interface{}{
 					"data1": "datavalue1",
 				},
+				Owners: []user.User{{Email: "dummy@trash.com"}},
 				Labels: map[string]string{
 					"label1": "labelvalue1",
 				},
@@ -1383,9 +1388,10 @@ func TestAssetToProto(t *testing.T) {
 				UpdatedAt: timeDummy,
 			},
 			ExpectProto: &compassv1beta1.Asset{
-				Id:   "id1",
-				Urn:  "urn1",
-				Data: dataPB,
+				Id:     "id1",
+				Urn:    "urn1",
+				Data:   dataPB,
+				Owners: []*compassv1beta1.User{{Email: "dummy@trash.com"}},
 				Labels: map[string]string{
 					"label1": "labelvalue1",
 				},

--- a/internal/server/v1beta1/user.go
+++ b/internal/server/v1beta1/user.go
@@ -248,10 +248,9 @@ func (server *APIServer) buildGetDiscussionsFilter(req *compassv1beta1.GetMyDisc
 
 // userToProto transforms struct with some fields only to proto
 func userToProto(u user.User) *compassv1beta1.User {
-	if u.UUID == "" {
+	if u == (user.User{}) {
 		return nil
 	}
-
 	return &compassv1beta1.User{
 		Uuid:  u.UUID,
 		Email: u.Email,
@@ -260,10 +259,9 @@ func userToProto(u user.User) *compassv1beta1.User {
 
 // userToFullProto transforms struct with all fields to proto
 func userToFullProto(u user.User) *compassv1beta1.User {
-	if u.UUID == "" {
+	if u == (user.User{}) {
 		return nil
 	}
-
 	var createdAtPB *timestamppb.Timestamp
 	if !u.CreatedAt.IsZero() {
 		createdAtPB = timestamppb.New(u.CreatedAt)


### PR DESCRIPTION
When assets are sinked to Compass from Meteor, the UUID is not populated for the asset owners. This meant that fetching the asset either by ID or while listing the assets, the owner info (email) was not being returned because of a filter condition on UUID.

Include the owner's information available in the datastore irrespective of whether UUID was populated or not.

Closes #186 