### PR TITLE
fix: populate version in assets_versions for 1st entry

### DIFF
--- a/internal/store/postgres/migrations/000016_update_assets_versions.up.sql
+++ b/internal/store/postgres/migrations/000016_update_assets_versions.up.sql
@@ -1,0 +1,1 @@
+UPDATE assets_versions SET version = '0.1' WHERE version = '';


### PR DESCRIPTION
- Set version to 0.1 while inserting the first version of asset into
  assets_versions table.
- Update all rows in assets_versions to have 0.1 as the version if the
  column was not populated.

Closes: #215  